### PR TITLE
Change device_state_attributes

### DIFF
--- a/custom_components/overseerr/sensor.py
+++ b/custom_components/overseerr/sensor.py
@@ -58,7 +58,7 @@ class OverseerrSensor(Entity):
         return self._state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Attributes."""
         return self._last_request
 


### PR DESCRIPTION
device_state_attributes has been renamed to extra_state_attributes as mentioned in the HA documentation: https://dev-docs.home-assistant.io/en/master/api/helpers.html
```
property device_state_attributes
Return entity specific state attributes.

This method is deprecated, platform classes should implement extra_state_attributes instead.
```
Will fix the error `WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.overseerr_total_requests (<class 'custom_components.overseerr.sensor.OverseerrSensor'>) implements device_state_attributes. Please report it to the custom component author.`