### PR TITLE
Handle hass.components deprecation, directly import discovery helper

### DIFF
--- a/custom_components/overseerr/__init__.py
+++ b/custom_components/overseerr/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
 )
 import homeassistant.helpers.config_validation as cv
-
+from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.event import track_time_interval
 
 from .const import (
@@ -196,7 +196,7 @@ def setup(hass, config):
         schema=SERVICE_UPDATE_REQUEST_SCHEMA,
     )
     
-    hass.helpers.discovery.load_platform("sensor", DOMAIN, {}, config)
+    load_platform(hass, "sensor", DOMAIN, {}, config)
  
     webhook_id = config[DOMAIN].get(CONF_API_KEY)
     _LOGGER.debug("webhook_id: %s", webhook_id)

--- a/custom_components/overseerr/__init__.py
+++ b/custom_components/overseerr/__init__.py
@@ -8,6 +8,7 @@ import json
 
 from datetime import timedelta
 
+from homeassistant.components.webhook import async_register, async_generate_url
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_API_KEY,
@@ -202,9 +203,9 @@ def setup(hass, config):
 
     _LOGGER.info("Overseerr Installing Webhook")
 
-    hass.components.webhook.async_register(DOMAIN, "Overseerr", webhook_id, handle_webhook)
+    async_register(hass, DOMAIN, "Overseerr", webhook_id, handle_webhook)
 
-    url = hass.components.webhook.async_generate_url(webhook_id)
+    url = async_generate_url(hass, webhook_id)
     _LOGGER.debug("webhook data: %s", url)
 
     # register scan interval


### PR DESCRIPTION
Starting with Home Assistant `2024.3.0`, users will get a warning in their log to open an issue on your repository regarding the use of `hass.components.webhook`. With Home Assistant `2024.9.0`, this use will stop working.

See [related developer blog post](https://developers.home-assistant.io/blog/2024/02/27/deprecate-bind-hass-and-hass-components) regarding the deprecation.

This PR is an attempt to get ahead of this issue so that you don't have issues opened on your repo and the integration continues to function.

### Changes:

* Explicitly import the desired functions (`async_register`, `async_generate_url`) from hass.components.webhook


### Update (4/27/24):

Added additional commit to directly import `load_platform` function from discovery helper. Using `hass.helpers` will be deprecated starting with Home Assistant `2024.11.0` - See [related developer blog post](https://developers.home-assistant.io/blog/2024/03/30/deprecate-hass-helpers).